### PR TITLE
Removed redundant defaults (_fixedpoint_to_posit)

### DIFF
--- a/src/sgposit/pcposit.py
+++ b/src/sgposit/pcposit.py
@@ -237,7 +237,7 @@ class PCPosit:
 
 
     @classmethod
-    def _fixedpoint_to_posit(cls, x, m, nbits=None, es=None):
+    def _fixedpoint_to_posit(cls, x, m, nbits, es):
         assert nbits is not None
         assert es is not None
 


### PR DESCRIPTION
`_fixedpoint_to_posit` had `nbits` and `es` as kwargs, with defaults set to None. The very next lines assert that those kwargs are never left as the default None. Thus, the kwargs has been simplified to positional args.