### PR TITLE
Moved docstrings into functions

### DIFF
--- a/src/sgposit/bitops.py
+++ b/src/sgposit/bitops.py
@@ -21,21 +21,21 @@
 # SOFTWARE.
 
 
-"""
-Create a mask with n ones.
-"""
 def create_mask(n):
+    """
+    Create a mask with n ones.
+    """
     if n <= 0:
         return 0
     return (1 << n) - 1
 
 
-"""
-Get bits in integer v from bit ifirst to bit ilast, inclusive.
-Integer v = b_n-1, ..., b_1, b_0
-The bit position is 0-based and starts from the least significant bit.
-"""
 def get_int_bits(v, ifirst, ilast=None):
+    """
+    Get bits in integer v from bit ifirst to bit ilast, inclusive.
+    Integer v = b_n-1, ..., b_1, b_0
+    The bit position is 0-based and starts from the least significant bit.
+    """
     if ilast is None: ilast = ifirst
 
     assert ifirst >= 0 and ifirst <= ilast
@@ -47,12 +47,12 @@ def get_int_bits(v, ifirst, ilast=None):
     return v
 
 
-"""
-Count the number of leading bits with value b, from bit ilast down to bit 0.
-Integer v = b_n-1, ..., b_1, b_0
-The bit position is 0-based and starts from the least significant bit.
-"""
 def count_leading_bits(bits, b, ilast):
+    """
+    Count the number of leading bits with value b, from bit ilast down to bit 0.
+    Integer v = b_n-1, ..., b_1, b_0
+    The bit position is 0-based and starts from the least significant bit.
+    """
     assert ilast >= 0
 
     count = 0

--- a/src/sgposit/coder.py
+++ b/src/sgposit/coder.py
@@ -215,9 +215,11 @@ def encode_posit_binary(rep):
     return bits
 
 
-# rep: normal posit representation,
-# return (sign, intpart, num, den) where number = sign*(intpart + num/den)
 def positrep_normal_to_rational(rep):
+    """
+    rep: normal posit representation
+    return (sign, intpart, num, den) where number = sign*(intpart + num/den)
+    """
     assert rep['t'] == 'n'
 
     E = (2**rep['es'] * rep['k']) + rep['e']
@@ -247,8 +249,10 @@ def positrep_normal_to_rational(rep):
     return (sign, intpart, num, den)
 
 
-# rational: (sign, intpart, num, den) where number = sign*(intpart + num/den)
 def rational_to_str(rational, separate_intpart=False):
+    """
+    rational: (sign, intpart, num, den) where number = sign*(intpart + num/den)
+    """
 
     (sign, intpart, num, den) = rational
 

--- a/src/sgposit/pcposit.py
+++ b/src/sgposit/pcposit.py
@@ -27,11 +27,11 @@ import operator
 from sgposit import coder
 
 
-"""
-Provably correct posit number arithmetic.
-"""
 class PCPosit:
-
+    """
+    Provably correct posit number arithmetic.
+    """
+    
     def __init__(self, v=None, mode=None, nbits=None, es=None):
         nbits_given = True
         es_given = True
@@ -218,8 +218,10 @@ class PCPosit:
         return op(xa, xb)
 
 
-    # Return (x,m) representing number = x * 2^m
     def _fixedpoint(self):
+        """
+        Return (x,m) representing number = x * 2^m
+        """
         rep = self.rep
 
         assert rep['t'] != 'c'


### PR DESCRIPTION
If the first line of a function is a triple-quoted string, that become the function's docstring, accessible with e.g. `__doc__` and `help()`. Here, the comments were originally triple-quoted, but outside their respective functions.